### PR TITLE
Improve CycleOrmBootloader bindings

### DIFF
--- a/src/Bootloader/CycleOrmBootloader.php
+++ b/src/Bootloader/CycleOrmBootloader.php
@@ -54,7 +54,10 @@ final class CycleOrmBootloader extends Bootloader
         $finalizer->addFinalizer(
             static function () use ($container): void {
                 if ($container->hasInstance(EntityManagerInterface::class)) {
-                    $container->get(EntityManagerInterface::class)->clean(true);
+                    $container->get(EntityManagerInterface::class)->clean();
+                }
+                if ($container->hasInstance(ORMInterface::class)) {
+                    $container->get(ORMInterface::class)->getHeap()->clean();
                 }
             }
         );

--- a/src/Bootloader/CycleOrmBootloader.php
+++ b/src/Bootloader/CycleOrmBootloader.php
@@ -18,6 +18,7 @@ use Cycle\ORM\TransactionInterface;
 use Psr\Container\ContainerInterface;
 use Spiral\Boot\AbstractKernel;
 use Spiral\Boot\Bootloader\Bootloader;
+use Spiral\Boot\EnvironmentInterface;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Config\ConfiguratorInterface;
 use Spiral\Core\Container;
@@ -50,6 +51,7 @@ final class CycleOrmBootloader extends Bootloader
     public function boot(
         Container $container,
         FinalizerInterface $finalizer,
+        EnvironmentInterface $env,
     ): void {
         $finalizer->addFinalizer(
             static function () use ($container): void {
@@ -64,7 +66,7 @@ final class CycleOrmBootloader extends Bootloader
 
         $container->bindInjector(RepositoryInterface::class, RepositoryInjector::class);
 
-        $this->initOrmConfig();
+        $this->initOrmConfig($env);
     }
 
     public function start(AbstractKernel $kernel): void
@@ -102,17 +104,18 @@ final class CycleOrmBootloader extends Bootloader
         return $factory;
     }
 
-    private function initOrmConfig(): void
+    private function initOrmConfig(EnvironmentInterface $env): void
     {
         $this->config->setDefaults(
             CycleConfig::CONFIG,
             [
                 'schema' => [
-                    'cache' => true,
+                    'cache' => $env->get('CYCLE_SCHEMA_CACHE', false),
                     'generators' => null,
                     'defaults' => [],
                     'collections' => [],
                 ],
+                'warmup' => $env->get('CYCLE_SCHEMA_WARMUP', false),
             ]
         );
     }

--- a/src/Bootloader/CycleOrmBootloader.php
+++ b/src/Bootloader/CycleOrmBootloader.php
@@ -18,7 +18,6 @@ use Cycle\ORM\TransactionInterface;
 use Psr\Container\ContainerInterface;
 use Spiral\Boot\AbstractKernel;
 use Spiral\Boot\Bootloader\Bootloader;
-use Spiral\Boot\EnvironmentInterface;
 use Spiral\Boot\FinalizerInterface;
 use Spiral\Config\ConfiguratorInterface;
 use Spiral\Core\Container;
@@ -35,11 +34,11 @@ final class CycleOrmBootloader extends Bootloader
 
     protected const BINDINGS = [
         TransactionInterface::class => Transaction::class,
-        EntityManagerInterface::class => EntityManager::class,
     ];
 
     protected const SINGLETONS = [
         ORMInterface::class => ORM::class,
+        EntityManagerInterface::class => EntityManager::class,
         FactoryInterface::class => [self::class, 'factory'],
     ];
 
@@ -51,12 +50,11 @@ final class CycleOrmBootloader extends Bootloader
     public function boot(
         Container $container,
         FinalizerInterface $finalizer,
-        EnvironmentInterface $env
     ): void {
         $finalizer->addFinalizer(
             static function () use ($container): void {
-                if ($container->hasInstance(ORMInterface::class)) {
-                    $container->get(ORMInterface::class)->getHeap()->clean();
+                if ($container->hasInstance(EntityManagerInterface::class)) {
+                    $container->get(EntityManagerInterface::class)->clean(true);
                 }
             }
         );

--- a/tests/src/Bootloader/CycleOrmBootloaderTest.php
+++ b/tests/src/Bootloader/CycleOrmBootloaderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Bootloader;
 
+use Cycle\ORM\EntityManager;
 use Cycle\ORM\EntityManagerInterface;
 use Cycle\ORM\FactoryInterface;
 use Cycle\ORM\ORM;
@@ -34,6 +35,7 @@ final class CycleOrmBootloaderTest extends BaseTest
 
     public function testGetsEntityManager(): void
     {
+        $this->assertContainerBoundAsSingleton(EntityManagerInterface::class, EntityManager::class);
         $this->assertContainerBound(EntityManagerInterface::class);
     }
 

--- a/tests/src/Bootloader/CycleOrmBootloaderTest.php
+++ b/tests/src/Bootloader/CycleOrmBootloaderTest.php
@@ -36,7 +36,6 @@ final class CycleOrmBootloaderTest extends BaseTest
     public function testGetsEntityManager(): void
     {
         $this->assertContainerBoundAsSingleton(EntityManagerInterface::class, EntityManager::class);
-        $this->assertContainerBound(EntityManagerInterface::class);
     }
 
     #[ConfigAttribute(path: 'cycle.schema.collections', value: ['default' => 'test'])]

--- a/tests/src/Bootloader/CycleOrmWarmedUpBootloaderTest.php
+++ b/tests/src/Bootloader/CycleOrmWarmedUpBootloaderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Bootloader;
 
+use Cycle\ORM\EntityManagerInterface;
 use Cycle\ORM\Heap\HeapInterface;
 use Cycle\ORM\ORM;
 use Cycle\ORM\ORMInterface;
@@ -43,6 +44,13 @@ final class CycleOrmWarmedUpBootloaderTest extends BaseTest
         $this->beforeStarting(static function (Container $container) use ($orm) {
             $container->bindSingleton(ORMInterface::class, $orm);
             $container->bindSingleton(ORM::class, $orm);
+        });
+
+        $em = m::mock(EntityManagerInterface::class);
+        $em->shouldReceive('clean');
+
+        $this->beforeStarting(static function (Container $container) use ($em) {
+            $container->bindSingleton(EntityManagerInterface::class, $em);
         });
 
         parent::setUp();

--- a/tests/src/Cycle/EntityManagerTest.php
+++ b/tests/src/Cycle/EntityManagerTest.php
@@ -64,7 +64,7 @@ final class EntityManagerTest extends BaseTest
         $em = $this->createMock(EntityManagerInterface::class);
         $em->expects($this->once())->method('clean');
 
-        $this->getContainer()->bindSingleton(EntityManagerInterface::class, fn(): EntityManagerInterface => $em);
+        $this->getContainer()->bindSingleton(EntityManagerInterface::class, $em);
         $this->getContainer()->get(EntityManagerInterface::class);
         $this->getContainer()->get(FinalizerInterface::class)->finalize();
     }

--- a/tests/src/Cycle/EntityManagerTest.php
+++ b/tests/src/Cycle/EntityManagerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Cycle;
+
+use Cycle\Database\DatabaseInterface;
+use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\ORMInterface;
+use Cycle\ORM\Schema;
+use Cycle\ORM\SchemaInterface;
+use Spiral\Boot\FinalizerInterface;
+use Spiral\Tests\BaseTest;
+use Spiral\Tests\Cycle\Fixture\Bar;
+
+final class EntityManagerTest extends BaseTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $db = $this->getContainer()->get(DatabaseInterface::class);
+
+        $bars = $db->table('bars')->getSchema();
+        $bars->primary('id');
+        $bars->string('name');
+        $bars->save();
+    }
+
+    public function testEntityManagerStateCanBeSharedAndFinalizeAtOnce(): void
+    {
+        $orm = $this->getOrm()->with(
+            new Schema([
+                Bar::class => [
+                    SchemaInterface::ROLE => 'bar',
+                    SchemaInterface::MAPPER => Mapper::class,
+                    SchemaInterface::DATABASE => 'default',
+                    SchemaInterface::TABLE => 'bars',
+                    SchemaInterface::PRIMARY_KEY => 'id',
+                    SchemaInterface::COLUMNS => ['id', 'name'],
+                    SchemaInterface::SCHEMA => [],
+                    SchemaInterface::RELATIONS => [],
+                ],
+            ])
+        );
+
+        $this->getContainer()->bindSingleton(ORMInterface::class, fn(): ORMInterface => $orm);
+
+        $em = $this->getEntityManager();
+        $em->persist(new Bar('foo'));
+        $em->run();
+        $bar = $this->getRepository(Bar::class)->findOne(['name' => 'foo']);
+        self::assertEquals('foo', $bar->name);
+        $bar->name = 'baz';
+        $em->persist($bar);
+        $this->getContainer()->get(FinalizerInterface::class)->finalize();
+        $em->run();
+        self::assertNull($this->getRepository(Bar::class)->findOne(['name' => 'baz']));
+    }
+}

--- a/tests/src/Cycle/EntityManagerTest.php
+++ b/tests/src/Cycle/EntityManagerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiral\Tests\Cycle;
 
 use Cycle\Database\DatabaseInterface;
+use Cycle\ORM\EntityManagerInterface;
 use Cycle\ORM\Mapper\Mapper;
 use Cycle\ORM\ORMInterface;
 use Cycle\ORM\Schema;
@@ -56,5 +57,15 @@ final class EntityManagerTest extends BaseTest
         $this->getContainer()->get(FinalizerInterface::class)->finalize();
         $em->run();
         self::assertNull($this->getRepository(Bar::class)->findOne(['name' => 'baz']));
+    }
+
+    public function testMethodCleanCalled(): void
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('clean');
+
+        $this->getContainer()->bindSingleton(EntityManagerInterface::class, fn(): EntityManagerInterface => $em);
+        $this->getContainer()->get(EntityManagerInterface::class);
+        $this->getContainer()->get(FinalizerInterface::class)->finalize();
     }
 }

--- a/tests/src/Cycle/Fixture/Bar.php
+++ b/tests/src/Cycle/Fixture/Bar.php
@@ -11,10 +11,10 @@ use Cycle\Annotated\Annotation\Entity;
 class Bar
 {
     #[Column(type: 'primary')]
-    public int $id;
+    public $id;
 
     #[Column(type: 'string')]
-    public string $name;
+    public $name;
 
     public function __construct(string $name)
     {

--- a/tests/src/Cycle/Fixture/Bar.php
+++ b/tests/src/Cycle/Fixture/Bar.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\Tests\Cycle\Fixture;
+
+use Cycle\Annotated\Annotation\Column;
+use Cycle\Annotated\Annotation\Entity;
+
+#[Entity]
+class Bar
+{
+    #[Column(type: 'primary')]
+    public int $id;
+
+    #[Column(type: 'string')]
+    public string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+}


### PR DESCRIPTION
Made the `EntityManagerInterface` a singleton, so that the `persist` and `run` operations could be called independently of each other and the operations on the entity were performed. Also, instead of clearing the heap with `ORMInterface`, did it using the `EntityManagerInterface::clean` method.

But I find it a bit strange that the `EntityManager` has an argument `$cleanHeap` in the `clean` method that is not in the `EntityManagerInterface`. IMHO, it should not be in `EntityManager` at all, so both heap and entity manager should be called in the finalizer as follows:

```php
$finalizer->addFinalizer(
    static function () use ($container): void {
       if ($container->hasInstance(EntityManagerInterface::class)) {
           $container->get(EntityManagerInterface::class)->clean();
       }

       if ($container->hasInstance(ORMInterface::class)) {
           $container->get(ORMInterface::class)->getHeap()->clean();
       }
});
```

And `EntityManager` should only create a new UnitOfWork instance:

```php
public function clean(): static
{
      $this->unitOfWork = new UnitOfWork($this->orm);

      return $this;
}
```