### PR TITLE
Adds default ENV variables for caching and warming ORM schema

### DIFF
--- a/src/Bootloader/CycleOrmBootloader.php
+++ b/src/Bootloader/CycleOrmBootloader.php
@@ -44,7 +44,8 @@ final class CycleOrmBootloader extends Bootloader
     ];
 
     public function __construct(
-        private ConfiguratorInterface $config
+        private ConfiguratorInterface $config,
+        private EnvironmentInterface $env
     ) {
     }
 
@@ -107,11 +108,12 @@ final class CycleOrmBootloader extends Bootloader
             CycleConfig::CONFIG,
             [
                 'schema' => [
-                    'cache' => true,
+                    'cache' => $this->env->get('CYCLE_SCHEMA_CACHE', false),
                     'generators' => null,
                     'defaults' => [],
                     'collections' => [],
                 ],
+                'warmup' => $this->env->get('CYCLE_SCHEMA_WARMUP', false),
             ]
         );
     }

--- a/tests/src/Bootloader/CycleOrmWarmedUpBootloaderTest.php
+++ b/tests/src/Bootloader/CycleOrmWarmedUpBootloaderTest.php
@@ -22,14 +22,12 @@ abstract class OrmWithPrepareServicesMockStub implements ORMInterface
 
 final class CycleOrmWarmedUpBootloaderTest extends BaseTest
 {
+    public const ENV = [
+        'CYCLE_SCHEMA_WARMUP' => true
+    ];
+
     protected function setUp(): void
     {
-        $this->beforeStarting(
-            \Closure::bind(static function (CycleConfig $config) {
-                $config->config['warmup'] = true;
-            }, null, CycleConfig::class)
-        );
-
         $orm = m::mock(OrmWithPrepareServicesMockStub::class);
         $orm->shouldAllowMockingMethod('prepareServices');
         $orm->shouldReceive('prepareServices')->once();

--- a/tests/src/Console/Command/CycleOrm/UpdateCommandTest.php
+++ b/tests/src/Console/Command/CycleOrm/UpdateCommandTest.php
@@ -14,7 +14,8 @@ final class UpdateCommandTest extends ConsoleTest
 {
     public const ENV = [
         'SAFE_MIGRATIONS' => true,
-        'USE_MIGRATIONS' => true
+        'USE_MIGRATIONS' => true,
+        'CYCLE_SCHEMA_CACHE' => true
     ];
 
     public function testGetSchema(): void
@@ -37,7 +38,7 @@ final class UpdateCommandTest extends ConsoleTest
         $memory = m::mock(MemoryInterface::class);
         $this->getContainer()->bind(MemoryInterface::class, $memory);
 
-        $memory->shouldReceive('saveData');
+        $memory->shouldReceive('saveData')->once();
         $memory->shouldReceive('loadData')->once()->andReturn(new Schema([]));
         $this->runCommand('cycle');
 


### PR DESCRIPTION
Now there is an ability to manage schema caching and warming without config file

```
CYCLE_SCHEMA_CACHE=true
CYCLE_SCHEMA_WARMUP=false
```