### PR TITLE
Allow using interfaces to declare repository in Entity attribute

### DIFF
--- a/src/Injector/RepositoryInjector.php
+++ b/src/Injector/RepositoryInjector.php
@@ -29,15 +29,15 @@ final class RepositoryInjector implements InjectorInterface
         foreach ($schema->getRoles() as $role) {
             $repository = $schema->define($role, SchemaInterface::REPOSITORY);
 
-            if ($repository !== Select\Repository::class && in_array($repository, $class->getInterfaceNames(), true)) {
-                return $this->orm->getRepository($role);
-            }
-
-            if ($repository !== Select\Repository::class && $repository === $class->getName()) {
-                return $this->orm->getRepository($role);
+            if ($repository !== Select\Repository::class) {
+                if ($repository === $class->getName() || \in_array($repository, $class->getInterfaceNames(), true)) {
+                    return $this->orm->getRepository($role);
+                }
             }
         }
 
-        throw new ORMException(sprintf('Unable to find Entity role for repository %s', $class->getName()));
+        throw new ORMException(
+            \sprintf('Unable to find Entity role for repository %s', $class->getName())
+        );
     }
 }

--- a/tests/app/Bootloader/AppBootloader.php
+++ b/tests/app/Bootloader/AppBootloader.php
@@ -4,17 +4,23 @@ declare(strict_types=1);
 
 namespace Spiral\App\Bootloader;
 
+use Spiral\App\Repositories\RoleRepository;
+use Spiral\App\Repositories\RoleRepositoryInterface;
 use Spiral\Bootloader\DomainBootloader;
 use Spiral\Core\CoreInterface;
 use Spiral\Cycle\Interceptor\CycleInterceptor;
 
 final class AppBootloader extends DomainBootloader
 {
+    protected const BINDINGS = [
+        RoleRepositoryInterface::class => RoleRepository::class
+    ];
+
     protected const SINGLETONS = [
-        CoreInterface::class => [self::class, 'domainCore']
+        CoreInterface::class => [self::class, 'domainCore'],
     ];
 
     protected const INTERCEPTORS = [
-        CycleInterceptor::class
+        CycleInterceptor::class,
     ];
 }

--- a/tests/app/Entities/Role.php
+++ b/tests/app/Entities/Role.php
@@ -6,8 +6,9 @@ namespace Spiral\App\Entities;
 
 use Cycle\Annotated\Annotation\Column;
 use Cycle\Annotated\Annotation\Entity;
+use Spiral\App\Repositories\RoleRepositoryInterface;
 
-#[Entity]
+#[Entity(repository: RoleRepositoryInterface::class)]
 class Role
 {
     #[Column(type: 'primary')]

--- a/tests/app/Repositories/RoleRepository.php
+++ b/tests/app/Repositories/RoleRepository.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\App\Repositories;
+
+use Cycle\ORM\Select\Repository;
+
+class RoleRepository extends Repository implements RoleRepositoryInterface
+{
+}

--- a/tests/app/Repositories/RoleRepositoryInterface.php
+++ b/tests/app/Repositories/RoleRepositoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\App\Repositories;
+
+use Cycle\ORM\RepositoryInterface;
+
+interface RoleRepositoryInterface extends RepositoryInterface
+{
+
+}

--- a/tests/src/Injector/RepositoryInjectorTest.php
+++ b/tests/src/Injector/RepositoryInjectorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Injector;
 
+use Cycle\ORM\RepositoryInterface;
 use Spiral\App\Repositories\RoleRepository;
 use Spiral\App\Repositories\RoleRepositoryInterface;
 use Spiral\App\Repositories\UserRepository;
@@ -20,5 +21,12 @@ final class RepositoryInjectorTest extends BaseTest
     public function testInjectRepositoryInterface(): void
     {
         $this->assertInstanceOf(RoleRepository::class, $this->getContainer()->get(RoleRepositoryInterface::class));
+    }
+
+    public function testInjectBaseRepositoryInterface(): void
+    {
+        $this->expectExceptionMessage('Unable to find Entity role for repository Cycle\ORM\RepositoryInterface');
+
+        $this->getContainer()->get(RepositoryInterface::class);
     }
 }

--- a/tests/src/Injector/RepositoryInjectorTest.php
+++ b/tests/src/Injector/RepositoryInjectorTest.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Injector;
 
-use Cycle\ORM\RepositoryInterface;
+use Spiral\App\Repositories\RoleRepository;
+use Spiral\App\Repositories\RoleRepositoryInterface;
 use Spiral\App\Repositories\UserRepository;
 use Spiral\Tests\BaseTest;
 
@@ -14,5 +15,10 @@ final class RepositoryInjectorTest extends BaseTest
     {
         # todo replace to $this->assertAutowireable
         $this->assertInstanceOf(UserRepository::class, $this->getContainer()->get(UserRepository::class));
+    }
+
+    public function testInjectRepositoryInterface(): void
+    {
+        $this->assertInstanceOf(RoleRepository::class, $this->getContainer()->get(RoleRepositoryInterface::class));
     }
 }


### PR DESCRIPTION
An interface is better than a concrete object for testing and supporting multiple databases

**Entity**
```php
namespace App\Entities;

use Cycle\Annotated\Annotation\Column;
use Cycle\Annotated\Annotation\Entity;
use App\Repositories\RoleRepositoryInterface;

#[Entity(
    repository: RoleRepositoryInterface::class
)]
class Role
{
    #[Column(type: 'primary')]
    public int $id;

    #[Column(type: 'string')]
    public string $name;

    public function __construct(string $name)
    {
        $this->name = $name;
    }
}
```

**Repository**
```php
// Interface
namespace App\Repositories;

use Cycle\ORM\RepositoryInterface;

interface RoleRepositoryInterface extends RepositoryInterface
{
     //...
}

// Implementation
namespace App\Repositories\MySQL;

use Cycle\ORM\Select\Repository;

class RoleRepository extends Repository implements RoleRepositoryInterface
{
}
```

**Binding**

```php
namespace App\Bootloader;

use App\Repositories;
use Spiral\Bootloader\DomainBootloader;
use Spiral\Core\CoreInterface;
use Spiral\Cycle\Interceptor\CycleInterceptor;

final class AppBootloader extends DomainBootloader
{
    protected const BINDINGS = [
        Repositories\RoleRepositoryInterface::class => Repositories\MySQL\RoleRepository::class
    ];

    // ...
}
```

**Usage**
```php
$repository = $container->get(\App\Repositories\RoleRepositoryInterface::class);
```