### PR TITLE
Added mermaid format to cycle:render command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "cycle/migrations": "^4.0",
     "cycle/orm": "^2.0.2",
     "cycle/schema-migrations-generator": "^3.0",
-    "cycle/schema-renderer": "^1.1",
+    "cycle/schema-renderer": "^1.3",
     "doctrine/inflector": "^1.4 || ^2.0",
     "spiral/attributes": "^2.10 || ^3.0",
     "spiral/framework": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "cycle/migrations": "^4.0",
     "cycle/orm": "^2.0.2",
     "cycle/schema-migrations-generator": "^3.0",
-    "cycle/schema-renderer": "dev-feature/mermaid as 1.0",
+    "cycle/schema-renderer": "^1.1",
     "doctrine/inflector": "^1.4 || ^2.0",
     "spiral/attributes": "^2.10 || ^3.0",
     "spiral/framework": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   "require": {
     "php": ">=8.1",
     "cycle/annotated": "^3.1",
-    "cycle/migrations": "^4.0",
+    "cycle/migrations": "^4.0.1",
     "cycle/orm": "^2.0.2",
     "cycle/schema-migrations-generator": "^3.0",
     "cycle/schema-renderer": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "cycle/migrations": "^4.0",
     "cycle/orm": "^2.0.2",
     "cycle/schema-migrations-generator": "^3.0",
-    "cycle/schema-renderer": "^1.3",
+    "cycle/schema-renderer": "^1.2",
     "doctrine/inflector": "^1.4 || ^2.0",
     "spiral/attributes": "^2.10 || ^3.0",
     "spiral/framework": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "cycle/migrations": "^4.0",
     "cycle/orm": "^2.0.2",
     "cycle/schema-migrations-generator": "^3.0",
-    "cycle/schema-renderer": "^1.1",
+    "cycle/schema-renderer": "dev-feature/mermaid as 1.0",
     "doctrine/inflector": "^1.4 || ^2.0",
     "spiral/attributes": "^2.10 || ^3.0",
     "spiral/framework": "^3.0",

--- a/src/Console/Command/CycleOrm/RenderCommand.php
+++ b/src/Console/Command/CycleOrm/RenderCommand.php
@@ -27,7 +27,10 @@ final class RenderCommand extends AbstractCommand
             'mermaid' => new MermaidRenderer(),
             'php' => new PhpSchemaRenderer(),
             'color' => new OutputSchemaRenderer(OutputSchemaRenderer::FORMAT_CONSOLE_COLOR),
-            default => new OutputSchemaRenderer(OutputSchemaRenderer::FORMAT_PLAIN_TEXT)
+            'plain' => new OutputSchemaRenderer(OutputSchemaRenderer::FORMAT_PLAIN_TEXT),
+            default => throw new \InvalidArgumentException(
+                sprintf('Format \'%s\' doesn\'t exists.', $this->argument('format'))
+            )
         };
 
         $output->writeln(

--- a/src/Console/Command/CycleOrm/RenderCommand.php
+++ b/src/Console/Command/CycleOrm/RenderCommand.php
@@ -29,7 +29,7 @@ final class RenderCommand extends AbstractCommand
             'color' => new OutputSchemaRenderer(OutputSchemaRenderer::FORMAT_CONSOLE_COLOR),
             'plain' => new OutputSchemaRenderer(OutputSchemaRenderer::FORMAT_PLAIN_TEXT),
             default => throw new \InvalidArgumentException(
-                sprintf('Format `%s` doesn\'t exists.', $this->argument('format'))
+                sprintf("Format `%s` doesn't exists.", $this->argument('format'))
             )
         };
 

--- a/src/Console/Command/CycleOrm/RenderCommand.php
+++ b/src/Console/Command/CycleOrm/RenderCommand.php
@@ -6,29 +6,29 @@ namespace Spiral\Cycle\Console\Command\CycleOrm;
 
 use Cycle\ORM\SchemaInterface;
 use Cycle\Schema\Renderer\OutputSchemaRenderer;
+use Cycle\Schema\Renderer\PhpSchemaRenderer;
 use Cycle\Schema\Renderer\SchemaToArrayConverter;
 use Spiral\Cycle\Console\Command\Migrate\AbstractCommand;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Cycle\Schema\Renderer\MermaidRenderer\MermaidRenderer;
 
 final class RenderCommand extends AbstractCommand
 {
-    protected const NAME = 'cycle:render';
+    protected const SIGNATURE = 'cycle:render {format=color : Output format}';
+
     protected const DESCRIPTION = 'Render available CycleORM schemas';
-    protected const OPTIONS = [
-        ['no-color', 'nc', InputOption::VALUE_NONE, 'Display output without colors.'],
-    ];
 
     public function perform(
         OutputInterface $output,
         SchemaInterface $schema,
         SchemaToArrayConverter $converter
     ): int {
-        $format = $this->option('no-color')  ?
-            OutputSchemaRenderer::FORMAT_PLAIN_TEXT :
-            OutputSchemaRenderer::FORMAT_CONSOLE_COLOR;
-
-        $renderer = new OutputSchemaRenderer($format);
+        $renderer = match ($this->argument('format')) {
+            'mermaid' => new MermaidRenderer(),
+            'php' => new PhpSchemaRenderer(),
+            'color' => new OutputSchemaRenderer(OutputSchemaRenderer::FORMAT_CONSOLE_COLOR),
+            default => new OutputSchemaRenderer(OutputSchemaRenderer::FORMAT_PLAIN_TEXT)
+        };
 
         $output->writeln(
             $renderer->render(

--- a/src/Console/Command/CycleOrm/RenderCommand.php
+++ b/src/Console/Command/CycleOrm/RenderCommand.php
@@ -29,7 +29,7 @@ final class RenderCommand extends AbstractCommand
             'color' => new OutputSchemaRenderer(OutputSchemaRenderer::FORMAT_CONSOLE_COLOR),
             'plain' => new OutputSchemaRenderer(OutputSchemaRenderer::FORMAT_PLAIN_TEXT),
             default => throw new \InvalidArgumentException(
-                sprintf("Format `%s` doesn't exists.", $this->argument('format'))
+                sprintf("Format `%s` isn't supported.", $this->argument('format'))
             )
         };
 

--- a/src/Console/Command/CycleOrm/RenderCommand.php
+++ b/src/Console/Command/CycleOrm/RenderCommand.php
@@ -29,7 +29,7 @@ final class RenderCommand extends AbstractCommand
             'color' => new OutputSchemaRenderer(OutputSchemaRenderer::FORMAT_CONSOLE_COLOR),
             'plain' => new OutputSchemaRenderer(OutputSchemaRenderer::FORMAT_PLAIN_TEXT),
             default => throw new \InvalidArgumentException(
-                sprintf('Format \'%s\' doesn\'t exists.', $this->argument('format'))
+                sprintf('Format `%s` doesn\'t exists.', $this->argument('format'))
             )
         };
 

--- a/tests/src/Console/Command/CycleOrm/RenderCommandTest.php
+++ b/tests/src/Console/Command/CycleOrm/RenderCommandTest.php
@@ -32,12 +32,30 @@ final class RenderCommandTest extends ConsoleTest
         ]);
     }
 
+    #[ConfigAttribute(path: 'cycle.schema.defaults', value: [
+        SchemaInterface::MAPPER => 'custom_mapper',
+        SchemaInterface::REPOSITORY => 'custom_repository',
+        SchemaInterface::SCOPE => 'custom_scope',
+        SchemaInterface::TYPECAST_HANDLER => [
+            \Cycle\ORM\Parser\Typecast::class,
+            'custom_typecast_handler',
+        ],
+    ])]
+    public function testRenderInColorFormat()
+    {
+        $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['format' => 'color'], [
+            '[35m[user][39m :: [32mdefault[39m.[32musers[39m',
+            'Entity: [34mSpiral\App\Entities\User[39m',
+            'Mapper: [34mcustom_mapper[39m'
+        ]);
+    }
+
     public function testRenderInInvalidFormat(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Format \'123\' doesn\'t exists.');
+        $this->expectExceptionMessage("Format `unknown` doesn't exists.");
 
-        $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['format' => '123']);
+        $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['format' => 'unknown']);
     }
 
     #[ConfigAttribute(path: 'cycle.schema.defaults', value: [

--- a/tests/src/Console/Command/CycleOrm/RenderCommandTest.php
+++ b/tests/src/Console/Command/CycleOrm/RenderCommandTest.php
@@ -53,7 +53,7 @@ final class RenderCommandTest extends ConsoleTest
     public function testRenderInInvalidFormat(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage("Format `unknown` doesn't exists.");
+        $this->expectExceptionMessage("Format `unknown` isn't supported.");
 
         $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['format' => 'unknown']);
     }

--- a/tests/src/Console/Command/CycleOrm/RenderCommandTest.php
+++ b/tests/src/Console/Command/CycleOrm/RenderCommandTest.php
@@ -10,13 +10,35 @@ use Cycle\ORM\SchemaInterface;
 
 final class RenderCommandTest extends ConsoleTest
 {
-    public function testRenderSchema(): void
+    public function testRenderDefaultFormat(): void
     {
-        $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['--no-color' => true], [
+        $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['format' => ''], [
             '[user] :: default.users',
             'Entity: Spiral\App\Entities\User',
             'Mapper: Cycle\ORM\Mapper\Mapper',
-            'Repository: Cycle\ORM\Select\Repository'
+            'Repository: Cycle\ORM\Select\Repository',
+        ]);
+    }
+
+    public function testRenderMermaidFormat(): void
+    {
+        $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['format' => 'mermaid'], [
+            'classDiagram',
+            'class user',
+            'class role',
+            'class token',
+            'user --> "nullable" user : friend',
+        ]);
+    }
+
+    public function testRenderPHPFormat(): void
+    {
+        $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['format' => 'php'], [
+            '<?php',
+            'declare(strict_types=1);',
+            'use Cycle\ORM\Relation;',
+            'use Cycle\ORM\SchemaInterface as Schema;',
+            'return [',
         ]);
     }
 
@@ -36,7 +58,7 @@ final class RenderCommandTest extends ConsoleTest
             'Repository: custom_repository',
             'Scope: custom_scope',
             'Typecast: Cycle\ORM\Parser\Typecast',
-            'custom_typecast_handler'
+            'custom_typecast_handler',
         ]);
     }
 }

--- a/tests/src/Console/Command/CycleOrm/RenderCommandTest.php
+++ b/tests/src/Console/Command/CycleOrm/RenderCommandTest.php
@@ -10,17 +10,7 @@ use Cycle\ORM\SchemaInterface;
 
 final class RenderCommandTest extends ConsoleTest
 {
-    public function testRenderDefaultFormat(): void
-    {
-        $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['format' => ''], [
-            '[user] :: default.users',
-            'Entity: Spiral\App\Entities\User',
-            'Mapper: Cycle\ORM\Mapper\Mapper',
-            'Repository: Cycle\ORM\Select\Repository',
-        ]);
-    }
-
-    public function testRenderMermaidFormat(): void
+    public function testRenderInMermaidFormat(): void
     {
         $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['format' => 'mermaid'], [
             'classDiagram',
@@ -31,7 +21,7 @@ final class RenderCommandTest extends ConsoleTest
         ]);
     }
 
-    public function testRenderPHPFormat(): void
+    public function testRenderInPHPFormat(): void
     {
         $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['format' => 'php'], [
             '<?php',
@@ -40,6 +30,14 @@ final class RenderCommandTest extends ConsoleTest
             'use Cycle\ORM\SchemaInterface as Schema;',
             'return [',
         ]);
+    }
+
+    public function testRenderInInvalidFormat(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Format \'123\' doesn\'t exists.');
+
+        $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['format' => '123']);
     }
 
     #[ConfigAttribute(path: 'cycle.schema.defaults', value: [
@@ -53,7 +51,7 @@ final class RenderCommandTest extends ConsoleTest
     ])]
     public function testRedefineSchemaDefaults()
     {
-        $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['--no-color' => true], [
+        $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['format' => 'plain'], [
             'Mapper: custom_mapper',
             'Repository: custom_repository',
             'Scope: custom_scope',


### PR DESCRIPTION
Adds mermaid formatter

```bash
php app.php cycle:render mermaid
```

```mermaid
classDiagram
class movie {
    int id
    string title
    string description
    duration duration
}

class screening {
    int id
    string starts_at
    money price
    int movie_id
    int auditorium_id
    reservedSeats(HM: reservedSeat)
    movie(BT: movie)
    auditorium(BT: auditorium)
}
screening --o reservedSeat : reservedSeats
screening --> movie : movie
screening --> auditorium : auditorium
class auditorium {
    int id
    string name
    seats(HM: seat)
}
auditorium --o seat : seats
class seat {
    int id
    int row
    int number
    int auditorium_id
    auditorium(BT: auditorium)
}
seat --> auditorium : auditorium
class reservedSeat {
    int id
    int screening_id
    int seat_id
    string reservation_uuid
    screening(BT: screening)
    seat(BT: seat)
    reservation(BT: reservation)
}
reservedSeat --> screening : screening
reservedSeat --> seat : seat
reservedSeat --> reservation : reservation
class type {
    int id
    string name
}

class reservation {
    string created_at
    string expires_at
    string paid_at
    string canceled_at
    string transaction_id
    string uuid
    string user_id
    int screening_id
    int type_id
    seats(HM: reservedSeat)
    screening(BT: screening)
    type(BT: type)
}
reservation --o reservedSeat : seats
reservation --> screening : screening
reservation --> type : type
class token {
    string id
    string hashed_value
    string created_at
    string expires_at
    string payload
}
```