### PR TITLE
Redesigned auth token registration.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "cycle/schema-renderer": "^1.2",
     "doctrine/inflector": "^1.4 || ^2.0",
     "spiral/attributes": "^2.10 || ^3.0",
-    "spiral/framework": "^3.0",
+    "spiral/framework": "^3.3",
     "spiral/reactor": "^3.0",
     "spiral/scaffolder": "^3.0",
     "spiral/prototype": "^3.0",

--- a/src/Bootloader/AuthTokensBootloader.php
+++ b/src/Bootloader/AuthTokensBootloader.php
@@ -6,7 +6,6 @@ namespace Spiral\Cycle\Bootloader;
 
 use Spiral\Cycle\Auth\Token;
 use Spiral\Cycle\Auth\TokenStorage as CycleStorage;
-use Spiral\Auth\TokenStorageInterface;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Bootloader\Auth\HttpAuthBootloader;
 use Spiral\Tokenizer\Bootloader\TokenizerBootloader;
@@ -14,18 +13,17 @@ use Spiral\Tokenizer\Bootloader\TokenizerBootloader;
 final class AuthTokensBootloader extends Bootloader
 {
     protected const DEPENDENCIES = [
-        HttpAuthBootloader::class,
         CycleOrmBootloader::class,
         AnnotatedBootloader::class,
     ];
 
-    protected const SINGLETONS = [
-        TokenStorageInterface::class => CycleStorage::class,
-    ];
+    public function init(
+        TokenizerBootloader $tokenizer,
+        HttpAuthBootloader $bootloader,
+    ): void {
+        $bootloader->addTokenStorage('cycle', CycleStorage::class);
 
-    public function init(TokenizerBootloader $tokenizer): void
-    {
         $tokenClass = new \ReflectionClass(Token::class);
-        $tokenizer->addDirectory(dirname($tokenClass->getFileName()));
+        $tokenizer->addDirectory(\dirname($tokenClass->getFileName()));
     }
 }

--- a/src/Bootloader/AuthTokensBootloader.php
+++ b/src/Bootloader/AuthTokensBootloader.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Spiral\Cycle\Bootloader;
 
+use Spiral\Auth\Config\AuthConfig;
+use Spiral\Boot\EnvironmentInterface;
+use Spiral\Config\ConfiguratorInterface;
+use Spiral\Config\Patch\Set;
 use Spiral\Cycle\Auth\Token;
 use Spiral\Cycle\Auth\TokenStorage as CycleStorage;
 use Spiral\Boot\Bootloader\Bootloader;
@@ -12,16 +16,33 @@ use Spiral\Tokenizer\Bootloader\TokenizerBootloader;
 
 final class AuthTokensBootloader extends Bootloader
 {
+    private const TOKEN_STORAGE_NAME = 'cycle';
+
     protected const DEPENDENCIES = [
         CycleOrmBootloader::class,
         AnnotatedBootloader::class,
     ];
 
+    public function __construct(
+        private readonly ConfiguratorInterface $config,
+    ) {
+    }
+
     public function init(
         TokenizerBootloader $tokenizer,
         HttpAuthBootloader $bootloader,
+        EnvironmentInterface $env
     ): void {
-        $bootloader->addTokenStorage('cycle', CycleStorage::class);
+        $bootloader->addTokenStorage(self::TOKEN_STORAGE_NAME, CycleStorage::class);
+
+        // This is a temporary fix and backward compatibility for case when AUTH_TOKEN_STORAGE is not set.
+        // TODO: Will be removed after release of spiral/framework 4.0.0
+        if ($env->get('AUTH_TOKEN_STORAGE') === null) {
+            $this->config->modify(
+                AuthConfig::CONFIG,
+                new Set('defaultStorage', self::TOKEN_STORAGE_NAME),
+            );
+        }
 
         $tokenClass = new \ReflectionClass(Token::class);
         $tokenizer->addDirectory(\dirname($tokenClass->getFileName()));

--- a/tests/src/Auth/TokenStorageTest.php
+++ b/tests/src/Auth/TokenStorageTest.php
@@ -6,6 +6,7 @@ namespace Spiral\Tests\Auth;
 
 use Spiral\Auth\TokenInterface;
 use Spiral\Auth\TokenStorageInterface;
+use Spiral\Auth\TokenStorageProviderInterface;
 use Spiral\Cycle\Auth\TokenStorage;
 use Spiral\Tests\BaseTest;
 
@@ -17,7 +18,7 @@ final class TokenStorageTest extends BaseTest
     {
         parent::setUp();
 
-        $this->storage = $this->getContainer()->get(TokenStorageInterface::class);
+        $this->storage = $this->getContainer()->get(TokenStorageProviderInterface::class)->getStorage('cycle');
     }
 
     public function testTokenShouldBeCreatedWithoutExpiration()

--- a/tests/src/Bootloader/AuthTokensBootloaderTest.php
+++ b/tests/src/Bootloader/AuthTokensBootloaderTest.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Bootloader;
 
-use Spiral\Auth\TokenStorageInterface;
+use Spiral\Auth\Config\AuthConfig;
 use Spiral\Cycle\Auth\Token;
-use Spiral\Cycle\Auth\TokenStorage as CycleStorage;
+use Spiral\Cycle\Auth\TokenStorage;
 use Spiral\Tests\BaseTest;
 
 final class AuthTokensBootloaderTest extends BaseTest
 {
     public function testGetsTokenStorage(): void
     {
-        $this->assertContainerBoundAsSingleton(TokenStorageInterface::class, CycleStorage::class);
+        $storages = $this->getConfig(AuthConfig::CONFIG)['storages'];
+        $this->assertSame(TokenStorage::class, $storages['cycle']);
     }
 
     public function testTokenEntityShouldBeRegisterInTokenizer(): void


### PR DESCRIPTION
Instead of binding to the `Spiral\Auth\TokenStorageInterface` it will register a cycle token storage that can be used by name.