### PR TITLE
Fixes bug with error causes when stopping RoadRunner with activated DisconnectsBootloader

### DIFF
--- a/src/Bootloader/DisconnectsBootloader.php
+++ b/src/Bootloader/DisconnectsBootloader.php
@@ -17,7 +17,11 @@ final class DisconnectsBootloader extends Bootloader
     public function init(FinalizerInterface $finalizer, ContainerInterface $container): void
     {
         $finalizer->addFinalizer(
-            function () use ($container): void {
+            function (bool $terminate) use ($container): void {
+                if ($terminate) {
+                    return;
+                }
+
                 /** @var DatabaseManager $dbal */
                 $dbal = $container->get(DatabaseManager::class);
                 foreach ($dbal->getDrivers() as $driver) {

--- a/tests/src/Bootloader/ScaffolderBootloaderTest.php
+++ b/tests/src/Bootloader/ScaffolderBootloaderTest.php
@@ -15,10 +15,13 @@ final class ScaffolderBootloaderTest extends BaseTest
         $config = $this->getConfig(ScaffolderConfig::CONFIG);
 
         $this->assertIsArray($config);
-        $this->assertIsArray($config['declarations']);
-        $this->assertIsArray($config['declarations']['migration']);
-        $this->assertIsArray($config['declarations']['entity']);
-        $this->assertIsArray($config['declarations']['repository']);
+
+        $declarations = $config['defaults']['declarations'] ?? $config['declarations'];
+
+        $this->assertIsArray($declarations);
+        $this->assertIsArray($declarations['migration']);
+        $this->assertIsArray($declarations['entity']);
+        $this->assertIsArray($declarations['repository']);
 
         $this->assertSame(
             [
@@ -26,7 +29,7 @@ final class ScaffolderBootloaderTest extends BaseTest
                 'postfix'   => 'Migration',
                 'class'     => Declaration\MigrationDeclaration::class,
             ],
-            $config['declarations']['migration']
+            $declarations['migration']
         );
 
         $this->assertSame(
@@ -37,7 +40,7 @@ final class ScaffolderBootloaderTest extends BaseTest
                     'annotated' => Declaration\Entity\AnnotatedDeclaration::class,
                 ],
             ],
-            $config['declarations']['entity']
+            $declarations['entity']
         );
 
         $this->assertSame(
@@ -46,7 +49,7 @@ final class ScaffolderBootloaderTest extends BaseTest
                 'postfix'   => 'Repository',
                 'class'     => Declaration\RepositoryDeclaration::class,
             ],
-            $config['declarations']['repository']
+            $declarations['repository']
         );
     }
 }


### PR DESCRIPTION
```
 PHP Fatal error:  Uncaught Error: Typed property Spiral\Core\Container::$container must not be accessed before initialization in /root/repos/spiral-apps/notifier-spiral/src/vendor/spiral/framework/src/Core/src/Container.php:143
Stack trace:
#0 /root/repos/spiral-apps/notifier-spiral/src/vendor/spiral/cycle-bridge/src/Bootloader/DisconnectsBootloader.php(22): Spiral\Core\Container->get()
#1 /root/repos/spiral-apps/notifier-spiral/src/vendor/spiral/framework/src/Boot/src/Finalizer.php(30): Spiral\Cycle\Bootloader\DisconnectsBootloader->Spiral\Cycle\Bootloader\{closure}()
#2 /root/repos/spiral-apps/notifier-spiral/src/vendor/spiral/framework/src/Boot/src/AbstractKernel.php(99): Spiral\Boot\Finalizer->finalize()
#3 [internal function]: Spiral\Boot\AbstractKernel->__destruct()
#4 {main}
  thrown in /root/repos/spiral-apps/notifier-spiral/src/vendor/spiral/framework/src/Core/src/Container.php on line 143

Fatal error: Uncaught Error: Typed property Spiral\Core\Container::$container must not be accessed before initialization in /root/repos/spiral-apps/notifier-spiral/src/vendor/spiral/framework/src/Core/src/Container.php on line 143

Error: Typed property Spiral\Core\Container::$container must not be accessed before initialization in /root/repos/spiral-apps/notifier-spiral/src/vendor/spiral/framework/src/Core/src/Container.php on line 143

Call Stack:
    0.7058   10628688   1. Spiral\Boot\AbstractKernel->__destruct() /root/repos/spiral-apps/notifier-spiral/src/vendor/spiral/framework/src/Boot/src/AbstractKernel.php:0
    0.7058   10628688   2. Spiral\Boot\Finalizer->finalize($terminate = TRUE) /root/repos/spiral-apps/notifier-spiral/src/vendor/spiral/framework/src/Boot/src/AbstractKernel.php:99
    0.7058   10628688   3. Spiral\Cycle\Bootloader\DisconnectsBootloader->Spiral\Cycle\Bootloader\{closure:/root/repos/spiral-apps/notifier-spiral/src/vendor/spiral/cycle-bridge/src/Bootloader/DisconnectsBootloader.php:20-26}(TRUE) /root/repos/spiral-apps/notifier-spiral/src/vendor/spiral/framework/src/Boot/src/Finalizer.php:30
    0.7058   10628688   4. Spiral\Core\Container->get($id = 'Cycle\\Database\\DatabaseManager', $context = ???) /root/repos/spiral-apps/notifier-spiral/src/vendor/spiral/cycle-bridge/src/Bootloader/DisconnectsBootloader.php:22
```