### PR TITLE
Fix support for defining custom relations

### DIFF
--- a/src/Bootloader/CycleOrmBootloader.php
+++ b/src/Bootloader/CycleOrmBootloader.php
@@ -84,7 +84,7 @@ final class CycleOrmBootloader extends Bootloader
         CycleConfig $config
     ): FactoryInterface {
         $relationConfig = new RelationConfig(
-            RelationConfig::getDefault()->toArray() + $config->getCustomRelations()
+            $config->getCustomRelations() + RelationConfig::getDefault()->toArray()
         );
 
         $factory = new Factory(


### PR DESCRIPTION
**What was changed**: The order of array merging in the RelationConfig was adjusted to give custom relations higher priority over default settings.

Previously:

```php
Copy code
$relationConfig = new RelationConfig(
    RelationConfig::getDefault()->toArray() + $config->getCustomRelations()
);
```

Now:

```php
Copy code
$relationConfig = new RelationConfig(
    $config->getCustomRelations() + RelationConfig::getDefault()->toArray()
);
```

**Why this change was made**: The current implementation does not allow customRelations to override default settings. By changing the merge order, custom relations now take precedence, enabling users to redefine default settings when necessary. This improves flexibility and allows for more tailored configurations.