### PR TITLE
feat(console): render Cycle schema to PHP file (+roles filter, overwrite)

### DIFF
--- a/src/Console/Command/CycleOrm/RenderCommand.php
+++ b/src/Console/Command/CycleOrm/RenderCommand.php
@@ -9,35 +9,175 @@ use Cycle\Schema\Renderer\OutputSchemaRenderer;
 use Cycle\Schema\Renderer\PhpSchemaRenderer;
 use Cycle\Schema\Renderer\SchemaToArrayConverter;
 use Spiral\Cycle\Console\Command\Migrate\AbstractCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Cycle\Schema\Renderer\MermaidRenderer\MermaidRenderer;
+use Spiral\Console\Attribute\AsCommand;
+use Spiral\Console\Attribute\Argument;
+use Spiral\Console\Attribute\Option;
 
+#[AsCommand(
+    name: 'cycle:render',
+    description: 'Render available CycleORM schemas')
+]
 final class RenderCommand extends AbstractCommand
 {
-    protected const SIGNATURE = 'cycle:render {format=color : Output format}';
-    protected const DESCRIPTION = 'Render available CycleORM schemas';
+    #[Argument(name: 'format', description: 'The format of the output')]
+    private string $format;
+
+    #[Option(name: 'output', shortcut: 'o', description: 'Path to file for saving schema (currently only for format=php)')]
+    private ?string $outputPath = null;
+
+    #[Option(name: 'overwrite', description: 'Overwrite existing output')]
+    private bool $overwrite = false;
+
+    #[Option(name: 'role', shortcut: 'r', description: 'Specify roles for output in schema (supports comma separated values)')]
+    private array $role = [];
 
     public function perform(
         OutputInterface $output,
         SchemaInterface $schema,
         SchemaToArrayConverter $converter,
-    ): int {
-        $renderer = match ($this->argument('format')) {
+    ): int
+    {
+        $renderer = match ($this->format) {
             'mermaid' => new MermaidRenderer(),
             'php' => new PhpSchemaRenderer(),
             'color' => new OutputSchemaRenderer(OutputSchemaRenderer::FORMAT_CONSOLE_COLOR),
             'plain' => new OutputSchemaRenderer(OutputSchemaRenderer::FORMAT_PLAIN_TEXT),
             default => throw new \InvalidArgumentException(
-                \sprintf("Format `%s` isn't supported.", $this->argument('format')),
+                \sprintf("Format `%s` isn't supported.", $this->format),
             ),
         };
 
-        $output->writeln(
-            $renderer->render(
-                $converter->convert($schema),
-            ),
-        );
+        $schemaArray = $converter->convert($schema);
+        $requestedRoles = $this->parseRolesOption($this->role);
+
+        $existingRoles = array_keys($schemaArray);
+        $rolesMap = [];
+        foreach ($existingRoles as $role) {
+            $rolesMap[\strtolower($role)] = true;
+        }
+
+        $resolvedRoles = [];
+        $unknownRoles  = [];
+
+        foreach ($requestedRoles as $role) {
+            $key = \strtolower($role);
+            if (isset($rolesMap[$key])) {
+                $resolvedRoles[$key] = true;
+            } else {
+                $unknownRoles[] = $role;
+            }
+        }
+
+        if ($requestedRoles !== []) {
+            $schemaArray = \array_intersect_key($schemaArray, $resolvedRoles);
+            if ($schemaArray === []) {
+                $output->writeln(\sprintf(
+                    '<comment>No roles matched the provided filter: %s</comment>',
+                    \implode(', ',  $requestedRoles)
+                ));
+            }
+        }
+
+        if ($unknownRoles !== [] && $schemaArray !== []) {
+            $output->writeln(\sprintf(
+                '<comment>Warning: unknown role(s) ignored: %s.</comment>',
+                \implode(', ',  $unknownRoles)
+            ));
+        }
+
+        $path = $this->outputPath;
+
+        if ($schemaArray === []) {
+            if ($path !== null) {
+                $output->writeln('<comment>Nothing to write.</comment>');
+            } else {
+                $output->writeln('');
+            }
+            return self::SUCCESS;
+        }
+
+        if ($path !== null) {
+            if ($this->format !== 'php') {
+                $this->error('The --output option is currently supported only with format=php.');
+                return self::FAILURE;
+            }
+
+            $dir = \dirname($path);
+
+            if ($dir !== '' && $dir !== '.' && !\is_dir($dir)) {
+                if (!\mkdir($dir, 0775, true) && !\is_dir($dir)) {
+                    $this->error(\sprintf('Failed to create directory: %s', $dir));
+                    return self::FAILURE;
+                }
+            }
+
+            $exists = \is_file($path);
+            if ($exists && !$this->overwrite) {
+                $this->error(\sprintf('File already exists: %s (use --overwrite to replace)', $path));
+                return self::FAILURE;
+            }
+
+            $rendered = $renderer->render($schemaArray);
+            $payload  = \rtrim($rendered, "\r\n") . \PHP_EOL;
+
+            $tmpDir = $dir === '.' ? \getcwd() : $dir;
+            $tmp = $tmpDir !== false ? \tempnam($tmpDir, 'schema_') : false;
+            if ($tmp === false) {
+                $this->error('Failed to create a temporary file.');
+                return self::FAILURE;
+            }
+
+            if (\file_put_contents($tmp, $payload) === false) {
+                @\unlink($tmp);
+                $this->error(\sprintf('Failed to write schema to temp file in "%s".', $tmpDir));
+                return self::FAILURE;
+            }
+
+            if (!\rename($tmp, $path)) {
+                if ($exists) {
+                    @\unlink($path);
+                    if (\rename($tmp, $path)) {
+                        @\chmod($path, 0664);
+                        $output->writeln(\sprintf('<info>Schema written to %s</info>', $path));
+                        return self::SUCCESS;
+                    }
+                }
+                @\unlink($tmp);
+                $this->error(\sprintf('Failed to move temp file to "%s".', $path));
+                return self::FAILURE;
+            }
+
+            @\chmod($path, 0664);
+            $output->writeln(\sprintf('<info>Schema written to %s</info>', $path));
+            return self::SUCCESS;
+        }
+
+        $rendered = $renderer->render($schemaArray);
+        $output->writeln($rendered);
 
         return self::SUCCESS;
+    }
+
+
+    /**
+     * @param array $raw
+     * @return array<string>
+     */
+    private function parseRolesOption(array $raw): array
+    {
+        $allRoles = [];
+        foreach ($raw as $piece) {
+            $roles = \array_map('trim', explode(',', $piece));
+            foreach ($roles as $role) {
+                if ($role !== '') {
+                    $allRoles[] = $role;
+                }
+            }
+        }
+        return \array_values(\array_unique($allRoles));
     }
 }

--- a/src/Console/Command/CycleOrm/RenderCommand.php
+++ b/src/Console/Command/CycleOrm/RenderCommand.php
@@ -9,8 +9,6 @@ use Cycle\Schema\Renderer\OutputSchemaRenderer;
 use Cycle\Schema\Renderer\PhpSchemaRenderer;
 use Cycle\Schema\Renderer\SchemaToArrayConverter;
 use Spiral\Cycle\Console\Command\Migrate\AbstractCommand;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Cycle\Schema\Renderer\MermaidRenderer\MermaidRenderer;
 use Spiral\Console\Attribute\AsCommand;
@@ -19,21 +17,21 @@ use Spiral\Console\Attribute\Option;
 
 #[AsCommand(
     name: 'cycle:render',
-    description: 'Render available CycleORM schemas')
-]
+    description: "Render Cycle ORM schema.\n\n"
+    . "Examples:\n"
+    . "  php app.php cycle:render user,post,comment\n"
+    . "  php app.php cycle:render --format=php --output=cycle-schema.php\n\n"
+)]
 final class RenderCommand extends AbstractCommand
 {
-    #[Argument(name: 'format', description: 'The format of the output')]
-    private string $format;
+    #[Argument(name: 'roles', description: 'Comma-separated roles to export (e.g. "user,post,comment"); omit to export full schema.')]
+    private array $roles = [];
 
-    #[Option(name: 'output', shortcut: 'o', description: 'Path to file for saving schema (currently only for format=php)')]
+    #[Option(name: 'output', shortcut: 'o', description: 'Write/overwrite output to file (path). If omitted, prints to STDOUT.')]
     private ?string $outputPath = null;
 
-    #[Option(name: 'overwrite', description: 'Overwrite existing output')]
-    private bool $overwrite = false;
-
-    #[Option(name: 'role', shortcut: 'r', description: 'Specify roles for output in schema (supports comma separated values)')]
-    private array $role = [];
+    #[Option(name: 'format', description: "Output format: php|mermaid|color|plain (default: 'color' for ANSI-capable terminals, otherwise 'plain').")]
+    private ?string $format = null;
 
     public function perform(
         OutputInterface $output,
@@ -41,19 +39,26 @@ final class RenderCommand extends AbstractCommand
         SchemaToArrayConverter $converter,
     ): int
     {
-        $renderer = match ($this->format) {
-            'mermaid' => new MermaidRenderer(),
-            'php' => new PhpSchemaRenderer(),
-            'color' => new OutputSchemaRenderer(OutputSchemaRenderer::FORMAT_CONSOLE_COLOR),
-            'plain' => new OutputSchemaRenderer(OutputSchemaRenderer::FORMAT_PLAIN_TEXT),
-            default => throw new \InvalidArgumentException(
-                \sprintf("Format `%s` isn't supported.", $this->format),
-            ),
-        };
+        if ($this->format === null) {
+            $renderer = new OutputSchemaRenderer(
+                $output->isDecorated() && $this->outputPath === null ?
+                    OutputSchemaRenderer::FORMAT_CONSOLE_COLOR : OutputSchemaRenderer::FORMAT_PLAIN_TEXT
+            );
+        } else {
+            $renderer = match ($this->format) {
+                'mermaid' => new MermaidRenderer(),
+                'php' => new PhpSchemaRenderer(),
+                'color' => new OutputSchemaRenderer(OutputSchemaRenderer::FORMAT_CONSOLE_COLOR),
+                'plain' => new OutputSchemaRenderer(OutputSchemaRenderer::FORMAT_PLAIN_TEXT),
+                default => throw new \InvalidArgumentException(
+                    \sprintf("Format `%s` isn't supported.", $this->format),
+                ),
+            };
+        }
 
         $schemaArray = $converter->convert($schema);
-        $requestedRoles = $this->parseRolesOption($this->role);
 
+        $requestedRoles = $this->parseRolesOption($this->roles);
         $existingRoles = array_keys($schemaArray);
         $rolesMap = [];
         foreach ($existingRoles as $role) {
@@ -61,7 +66,7 @@ final class RenderCommand extends AbstractCommand
         }
 
         $resolvedRoles = [];
-        $unknownRoles  = [];
+        $unknownRoles = [];
 
         foreach ($requestedRoles as $role) {
             $key = \strtolower($role);
@@ -75,39 +80,17 @@ final class RenderCommand extends AbstractCommand
         if ($requestedRoles !== []) {
             $schemaArray = \array_intersect_key($schemaArray, $resolvedRoles);
             if ($schemaArray === []) {
-                $output->writeln(\sprintf(
-                    '<comment>No roles matched the provided filter: %s</comment>',
-                    \implode(', ',  $requestedRoles)
-                ));
+                $output->writeln(\sprintf( '<comment>No roles matched the provided filter: %s</comment>', \implode(', ', $requestedRoles) ));
             }
         }
 
         if ($unknownRoles !== [] && $schemaArray !== []) {
-            $output->writeln(\sprintf(
-                '<comment>Warning: unknown role(s) ignored: %s.</comment>',
-                \implode(', ',  $unknownRoles)
-            ));
+            $output->writeln(\sprintf('<comment>Warning: unknown role(s) ignored: %s.</comment>', \implode(', ', $unknownRoles)));
         }
 
         $path = $this->outputPath;
-
-        if ($schemaArray === []) {
-            if ($path !== null) {
-                $output->writeln('<comment>Nothing to write.</comment>');
-            } else {
-                $output->writeln('');
-            }
-            return self::SUCCESS;
-        }
-
         if ($path !== null) {
-            if ($this->format !== 'php') {
-                $this->error('The --output option is currently supported only with format=php.');
-                return self::FAILURE;
-            }
-
             $dir = \dirname($path);
-
             if ($dir !== '' && $dir !== '.' && !\is_dir($dir)) {
                 if (!\mkdir($dir, 0775, true) && !\is_dir($dir)) {
                     $this->error(\sprintf('Failed to create directory: %s', $dir));
@@ -115,43 +98,19 @@ final class RenderCommand extends AbstractCommand
                 }
             }
 
-            $exists = \is_file($path);
-            if ($exists && !$this->overwrite) {
-                $this->error(\sprintf('File already exists: %s (use --overwrite to replace)', $path));
-                return self::FAILURE;
-            }
-
             $rendered = $renderer->render($schemaArray);
             $payload  = \rtrim($rendered, "\r\n") . \PHP_EOL;
 
-            $tmpDir = $dir === '.' ? \getcwd() : $dir;
-            $tmp = $tmpDir !== false ? \tempnam($tmpDir, 'schema_') : false;
-            if ($tmp === false) {
-                $this->error('Failed to create a temporary file.');
-                return self::FAILURE;
-            }
-
-            if (\file_put_contents($tmp, $payload) === false) {
-                @\unlink($tmp);
-                $this->error(\sprintf('Failed to write schema to temp file in "%s".', $tmpDir));
-                return self::FAILURE;
-            }
-
-            if (!\rename($tmp, $path)) {
-                if ($exists) {
-                    @\unlink($path);
-                    if (\rename($tmp, $path)) {
-                        @\chmod($path, 0664);
-                        $output->writeln(\sprintf('<info>Schema written to %s</info>', $path));
-                        return self::SUCCESS;
-                    }
+            if ($schemaArray !== []) {
+                if (\file_put_contents($path, $payload) === false) {
+                    $this->error(\sprintf('Failed to write schema to temp file in "%s".', $path));
+                    return self::FAILURE;
                 }
-                @\unlink($tmp);
-                $this->error(\sprintf('Failed to move temp file to "%s".', $path));
+            } else {
+                $this->error(\sprintf('Nothing to write to "%s".', $path));
                 return self::FAILURE;
             }
 
-            @\chmod($path, 0664);
             $output->writeln(\sprintf('<info>Schema written to %s</info>', $path));
             return self::SUCCESS;
         }

--- a/src/Console/Command/CycleOrm/RenderCommand.php
+++ b/src/Console/Command/CycleOrm/RenderCommand.php
@@ -15,12 +15,42 @@ use Spiral\Console\Attribute\AsCommand;
 use Spiral\Console\Attribute\Argument;
 use Spiral\Console\Attribute\Option;
 
+/**
+ * Renders Cycle ORM schema in various formats.
+ *
+ * Exports the complete Cycle ORM schema or specific entity roles to different
+ * output formats including PHP arrays, Mermaid diagrams, colored console output,
+ * or plain text. Output can be displayed in terminal or saved to a file.
+ *
+ * ```bash
+ * # Display full schema with colors (default for ANSI terminals)
+ * php app.php cycle:render
+ *
+ * # Display schema for specific entity roles only
+ * php app.php cycle:render user,post,comment
+ *
+ * # Export entire schema as PHP array to file
+ * php app.php cycle:render --format=php --output=cycle-schema.php
+ *
+ * # Export filtered schema to PHP file (short option)
+ * php app.php cycle:render user,post --format=php -o schema.php
+ *
+ * # Generate Mermaid ER diagram
+ * php app.php cycle:render --format=mermaid --output=schema.mmd
+ *
+ * # Export plain text schema without colors
+ * php app.php cycle:render --format=plain
+ *
+ * # Export specific roles as Mermaid diagram
+ * php app.php cycle:render user,post,comment --format=mermaid -o entities.mmd
+ *
+ * # Export to file with automatic directory creation
+ * php app.php cycle:render --format=php -o export/schemas/cycle-schema.php
+ * ```
+ */
 #[AsCommand(
     name: 'cycle:render',
-    description: "Render Cycle ORM schema.\n\n"
-    . "Examples:\n"
-    . "  php app.php cycle:render user,post,comment\n"
-    . "  php app.php cycle:render --format=php --output=cycle-schema.php\n\n"
+    description: 'Render Cycle ORM schema in various formats (php, mermaid, color, plain).',
 )]
 final class RenderCommand extends AbstractCommand
 {
@@ -37,29 +67,25 @@ final class RenderCommand extends AbstractCommand
         OutputInterface $output,
         SchemaInterface $schema,
         SchemaToArrayConverter $converter,
-    ): int
-    {
-        if ($this->format === null) {
-            $renderer = new OutputSchemaRenderer(
+    ): int {
+        $renderer = match ($this->format) {
+            'mermaid' => new MermaidRenderer(),
+            'php' => new PhpSchemaRenderer(),
+            'color' => new OutputSchemaRenderer(OutputSchemaRenderer::FORMAT_CONSOLE_COLOR),
+            'plain' => new OutputSchemaRenderer(OutputSchemaRenderer::FORMAT_PLAIN_TEXT),
+            null => new OutputSchemaRenderer(
                 $output->isDecorated() && $this->outputPath === null ?
-                    OutputSchemaRenderer::FORMAT_CONSOLE_COLOR : OutputSchemaRenderer::FORMAT_PLAIN_TEXT
-            );
-        } else {
-            $renderer = match ($this->format) {
-                'mermaid' => new MermaidRenderer(),
-                'php' => new PhpSchemaRenderer(),
-                'color' => new OutputSchemaRenderer(OutputSchemaRenderer::FORMAT_CONSOLE_COLOR),
-                'plain' => new OutputSchemaRenderer(OutputSchemaRenderer::FORMAT_PLAIN_TEXT),
-                default => throw new \InvalidArgumentException(
-                    \sprintf("Format `%s` isn't supported.", $this->format),
-                ),
-            };
-        }
+                    OutputSchemaRenderer::FORMAT_CONSOLE_COLOR : OutputSchemaRenderer::FORMAT_PLAIN_TEXT,
+            ),
+            default => throw new \InvalidArgumentException(
+                \sprintf("Format `%s` isn't supported.", $this->format),
+            ),
+        };
 
         $schemaArray = $converter->convert($schema);
 
         $requestedRoles = $this->parseRolesOption($this->roles);
-        $existingRoles = array_keys($schemaArray);
+        $existingRoles = \array_keys($schemaArray);
         $rolesMap = [];
         foreach ($existingRoles as $role) {
             $rolesMap[\strtolower($role)] = true;
@@ -80,7 +106,7 @@ final class RenderCommand extends AbstractCommand
         if ($requestedRoles !== []) {
             $schemaArray = \array_intersect_key($schemaArray, $resolvedRoles);
             if ($schemaArray === []) {
-                $output->writeln(\sprintf( '<comment>No roles matched the provided filter: %s</comment>', \implode(', ', $requestedRoles) ));
+                $output->writeln(\sprintf('<comment>No roles matched the provided filter: %s</comment>', \implode(', ', $requestedRoles)));
             }
         }
 
@@ -121,16 +147,14 @@ final class RenderCommand extends AbstractCommand
         return self::SUCCESS;
     }
 
-
     /**
-     * @param array $raw
      * @return array<string>
      */
     private function parseRolesOption(array $raw): array
     {
         $allRoles = [];
         foreach ($raw as $piece) {
-            $roles = \array_map('trim', explode(',', $piece));
+            $roles = \array_map('trim', \explode(',', $piece));
             foreach ($roles as $role) {
                 if ($role !== '') {
                     $allRoles[] = $role;

--- a/src/Console/Command/CycleOrm/RenderCommand.php
+++ b/src/Console/Command/CycleOrm/RenderCommand.php
@@ -85,65 +85,58 @@ final class RenderCommand extends AbstractCommand
         $schemaArray = $converter->convert($schema);
 
         $requestedRoles = $this->parseRolesOption($this->roles);
-        $existingRoles = \array_keys($schemaArray);
-        $rolesMap = [];
-        foreach ($existingRoles as $role) {
-            $rolesMap[\strtolower($role)] = true;
-        }
-
-        $resolvedRoles = [];
-        $unknownRoles = [];
-
-        foreach ($requestedRoles as $role) {
-            $key = \strtolower($role);
-            if (isset($rolesMap[$key])) {
-                $resolvedRoles[$key] = true;
-            } else {
-                $unknownRoles[] = $role;
-            }
-        }
 
         if ($requestedRoles !== []) {
-            $schemaArray = \array_intersect_key($schemaArray, $resolvedRoles);
-            if ($schemaArray === []) {
-                $output->writeln(\sprintf('<comment>No roles matched the provided filter: %s</comment>', \implode(', ', $requestedRoles)));
+            $lowerMap = [];
+            $resolvedRoles = [];
+            $unknownRoles = [];
+
+            foreach ($schemaArray as $role => $v) {
+                $lowerMap[\strtolower($role)] = $v;
             }
+
+            foreach ($requestedRoles as $role) {
+                $s = $schemaArray[$role] ?? $lowerMap[\strtolower($role)] ?? null;
+                $s === null
+                    ? $unknownRoles[] = $role
+                    : $resolvedRoles[$role] = $s;
+            }
+
+            $unknownRoles !== [] and $this->warning(\sprintf(
+                'No roles were found for `%s`.',
+                \implode('`, `', $unknownRoles),
+            ));
+            $schemaArray = $resolvedRoles;
+            unset($resolvedRoles, $lowerMap, $unknownRoles);
         }
 
-        if ($unknownRoles !== [] && $schemaArray !== []) {
-            $output->writeln(\sprintf('<comment>Warning: unknown role(s) ignored: %s.</comment>', \implode(', ', $unknownRoles)));
+        if ($schemaArray === []) {
+            return self::FAILURE;
         }
 
         $path = $this->outputPath;
-        if ($path !== null) {
-            $dir = \dirname($path);
-            if ($dir !== '' && $dir !== '.' && !\is_dir($dir)) {
-                if (!\mkdir($dir, 0775, true) && !\is_dir($dir)) {
-                    $this->error(\sprintf('Failed to create directory: %s', $dir));
-                    return self::FAILURE;
-                }
-            }
+        $rendered = $renderer->render($schemaArray);
 
-            $rendered = $renderer->render($schemaArray);
-            $payload  = \rtrim($rendered, "\r\n") . \PHP_EOL;
-
-            if ($schemaArray !== []) {
-                if (\file_put_contents($path, $payload) === false) {
-                    $this->error(\sprintf('Failed to write schema to temp file in "%s".', $path));
-                    return self::FAILURE;
-                }
-            } else {
-                $this->error(\sprintf('Nothing to write to "%s".', $path));
-                return self::FAILURE;
-            }
-
-            $output->writeln(\sprintf('<info>Schema written to %s</info>', $path));
+        if ($path === null) {
+            $output->writeln($rendered);
             return self::SUCCESS;
         }
 
-        $rendered = $renderer->render($schemaArray);
-        $output->writeln($rendered);
+        $dir = \dirname($path);
+        if ($dir !== '' && $dir !== '.' && !\is_dir($dir)) {
+            if (!\mkdir($dir, 0775, true) && !\is_dir($dir)) {
+                $this->error(\sprintf('Failed to create directory: %s.', $dir));
+                return self::FAILURE;
+            }
+        }
 
+
+        if (\file_put_contents($path, $rendered) === false) {
+            $this->error(\sprintf('Failed to write schema to file: %s.', $path));
+            return self::FAILURE;
+        }
+
+        $this->info(\sprintf('Schema successfully written to %s.', $path));
         return self::SUCCESS;
     }
 

--- a/tests/src/Console/Command/CycleOrm/RenderCommandTest.php
+++ b/tests/src/Console/Command/CycleOrm/RenderCommandTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Spiral\Tests\Console\Command\CycleOrm;
 
+use Spiral\Console\Console;
 use Spiral\Tests\ConfigAttribute;
 use Spiral\Tests\ConsoleTest;
 use Cycle\ORM\SchemaInterface;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Output\BufferedOutput;
 
 final class RenderCommandTest extends ConsoleTest
 {
@@ -76,5 +79,189 @@ final class RenderCommandTest extends ConsoleTest
             'Typecast: Cycle\ORM\Parser\Typecast',
             'custom_typecast_handler',
         ]);
+    }
+
+    public function testOutputOnlyForPhpFormat(): void
+    {
+        $out = \sys_get_temp_dir() . '/schema_' . bin2hex(\random_bytes(4)) . '.php';
+        @unlink($out);
+
+        $this->assertConsoleCommandOutputContainsStrings(
+            'cycle:render',
+            ['format' => 'mermaid', '--output' => $out],
+            ['The --output option is currently supported only with format=php.']
+        );
+
+        $this->assertFileDoesNotExist($out);
+    }
+
+    public function testWritesPhpSchemaToFile(): void
+    {
+        $out = \sys_get_temp_dir() . '/schema_' . bin2hex(\random_bytes(4)) . '.php';
+        @unlink($out);
+
+        $this->assertConsoleCommandOutputContainsStrings(
+            'cycle:render',
+            ['format' => 'php', '--output' => $out, '--overwrite' => true],
+            ['Schema written to']
+        );
+
+        $this->assertFileExists($out);
+        $schema = require $out;
+        $this->assertIsArray($schema);
+
+        @unlink($out);
+    }
+
+    public function testPreventOverwriteWithoutFlag(): void
+    {
+        $out = \sys_get_temp_dir() . '/schema_' . \bin2hex(\random_bytes(4)) . '.php';
+        \file_put_contents($out, "<?php return ['_touched' => true];");
+
+        $this->assertConsoleCommandOutputContainsStrings(
+            'cycle:render',
+            ['format' => 'php', '--output' => $out],
+            ['File already exists:', 'use --overwrite to replace']
+        );
+
+        // файл остался прежним
+        $schema = require $out;
+        $this->assertArrayHasKey('_touched', $schema);
+
+        @unlink($out);
+    }
+
+    public function testOverwriteWithFlag(): void
+    {
+        $out = \sys_get_temp_dir() . '/schema_' . \bin2hex(\random_bytes(4)) . '.php';
+        \file_put_contents($out, "<?php return ['_touched' => true];");
+
+        $this->assertConsoleCommandOutputContainsStrings(
+            'cycle:render',
+            ['format' => 'php', '--output' => $out, '--overwrite' => true],
+            ['Schema written to']
+        );
+
+        $schema = require $out;
+        $this->assertIsArray($schema);
+        $this->assertArrayNotHasKey('_touched', $schema);
+
+        @unlink($out);
+    }
+
+    public function testRolesFilterSubset(): void
+    {
+        $out = \sys_get_temp_dir() . '/schema_' . \bin2hex(\random_bytes(4)) . '.php';
+        @unlink($out);
+
+        // В фикстурах Spiral обычно есть роли 'user','role','token' (смотри существующий тест mermaid)
+        $requested = ['user', 'role'];
+
+        $this->assertConsoleCommandOutputContainsStrings(
+            'cycle:render',
+            ['format' => 'php', '--output' => $out, '--overwrite' => true, '--role' => [implode(',', $requested)]],
+            ['Schema written to']
+        );
+
+        $schema = require $out;
+        $this->assertIsArray($schema);
+
+        // Все ключи схемы должны быть из запрошенного набора
+        foreach (array_keys($schema) as $key) {
+            $this->assertContains($key, $requested);
+        }
+
+        @unlink($out);
+    }
+
+    public function testWarnOnUnknownRolesButProceed(): void
+    {
+        $out = \sys_get_temp_dir() . '/schema_' . \bin2hex(\random_bytes(4)) . '.php';
+        @unlink($out);
+
+        // 'user' существует, 'does_not_exist' — нет
+        $this->assertConsoleCommandOutputContainsStrings(
+            'cycle:render',
+            [
+                'format'    => 'php',
+                '--output'    => $out,
+                '--overwrite' => true,
+                '--role'      => ['user,does_not_exist'],
+            ],
+            [
+                'Warning: unknown role(s) ignored: does_not_exist.',
+                'Schema written to',
+            ]
+        );
+
+        $schema = require $out;
+        $this->assertIsArray($schema);
+        $this->assertArrayHasKey('user', $schema);
+        $this->assertArrayNotHasKey('does_not_exist', $schema);
+
+        @unlink($out);
+    }
+
+    public function testAllUnknownRolesLeadsToNothingToWrite(): void
+    {
+        $out = \sys_get_temp_dir() . '/schema_' . \bin2hex(\random_bytes(4)) . '.php';
+        @unlink($out);
+
+        $this->assertConsoleCommandOutputContainsStrings(
+            'cycle:render',
+            ['format' => 'php', '--output' => $out, '--role' => ['foo,bar']],
+            [
+                'Nothing to write.',
+            ]
+        );
+
+        $this->assertFileDoesNotExist($out);
+    }
+
+    public function testRolesCsvAndRepeatOptionsAreMerged(): void
+    {
+        $out = sys_get_temp_dir() . '/schema_' . bin2hex(random_bytes(4)) . '.php';
+        @unlink($out);
+
+        // проверяем смешанный ввод: повторяемая опция + CSV + разный регистр
+        $this->assertConsoleCommandOutputContainsStrings(
+            'cycle:render',
+            [
+                'format'    => 'php',
+                '--output'    => $out,
+                '--overwrite' => true,
+                '--role'      => ['User', 'role,address'],
+            ],
+            ['Schema written to']
+        );
+
+        $schema = require $out;
+        $this->assertIsArray($schema);
+
+        // ожидаем хотя бы user/role/token (если они есть в фикстуре)
+        $keys = array_keys($schema);
+        $this->assertNotEmpty($keys);
+        foreach ($keys as $k) {
+            $this->assertContains($k, ['user', 'role', 'address']);
+        }
+
+        @unlink($out);
+    }
+
+    public function testRolesFilterWorksForPlainStdout(): void
+    {
+        /** @var Console $console */
+        $console = $this->getContainer()->get(Console::class);
+
+        $out = new BufferedOutput();
+
+        $code = $console->run('cycle:render', ['format' => 'mermaid', '--role' => ['role']], $out);
+
+        $display = $out->fetch();
+
+        $this->assertStringContainsString('classDiagram', $display);
+        $this->assertStringContainsString('class role', $display);
+        $this->assertStringNotContainsString('class user', $display);
+        $this->assertStringNotContainsString('class address', $display);
     }
 }

--- a/tests/src/Console/Command/CycleOrm/RenderCommandTest.php
+++ b/tests/src/Console/Command/CycleOrm/RenderCommandTest.php
@@ -8,14 +8,13 @@ use Spiral\Console\Console;
 use Spiral\Tests\ConfigAttribute;
 use Spiral\Tests\ConsoleTest;
 use Cycle\ORM\SchemaInterface;
-use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 final class RenderCommandTest extends ConsoleTest
 {
     public function testRenderInMermaidFormat(): void
     {
-        $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['format' => 'mermaid'], [
+        $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['--format' => 'mermaid'], [
             'classDiagram',
             'class user',
             'class role',
@@ -26,7 +25,7 @@ final class RenderCommandTest extends ConsoleTest
 
     public function testRenderInPHPFormat(): void
     {
-        $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['format' => 'php'], [
+        $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['--format' => 'php'], [
             '<?php',
             'declare(strict_types=1);',
             'use Cycle\ORM\Relation;',
@@ -46,7 +45,7 @@ final class RenderCommandTest extends ConsoleTest
     ])]
     public function testRenderInColorFormat(): void
     {
-        $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['format' => 'color'], [
+        $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['--format' => 'color'], [
             '[35m[user][39m :: [32mdefault[39m.[32musers[39m',
             'Entity: [34mSpiral\App\Entities\User[39m',
             'Mapper: [34mcustom_mapper[39m',
@@ -58,7 +57,7 @@ final class RenderCommandTest extends ConsoleTest
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage("Format `unknown` isn't supported.");
 
-        $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['format' => 'unknown']);
+        $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['--format' => 'unknown']);
     }
 
     #[ConfigAttribute(path: 'cycle.schema.defaults', value: [
@@ -72,7 +71,7 @@ final class RenderCommandTest extends ConsoleTest
     ])]
     public function testRedefineSchemaDefaults(): void
     {
-        $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['format' => 'plain'], [
+        $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['--format' => 'plain'], [
             'Mapper: custom_mapper',
             'Repository: custom_repository',
             'Scope: custom_scope',
@@ -81,64 +80,74 @@ final class RenderCommandTest extends ConsoleTest
         ]);
     }
 
-    public function testOutputOnlyForPhpFormat(): void
+    /**
+     * @return array<string, array{0:string,1:bool,2:bool,3:bool}>
+     *              [format, expectAnsi, expectMermaidKeyword, expectPhp]
+     */
+    public static function fileFormatsProvider(): array
     {
-        $out = \sys_get_temp_dir() . '/schema_' . bin2hex(\random_bytes(4)) . '.php';
-        @unlink($out);
-
-        $this->assertConsoleCommandOutputContainsStrings(
-            'cycle:render',
-            ['format' => 'mermaid', '--output' => $out],
-            ['The --output option is currently supported only with format=php.']
-        );
-
-        $this->assertFileDoesNotExist($out);
+        return [
+            'plain'   => ['plain',   false, false, false],
+            'color'   => ['color',   true,  false, false],
+            'mermaid' => ['mermaid', false, true,  false],
+            'php'     => ['php',     false, false, true],
+        ];
     }
 
-    public function testWritesPhpSchemaToFile(): void
-    {
-        $out = \sys_get_temp_dir() . '/schema_' . bin2hex(\random_bytes(4)) . '.php';
+    /**
+     * @dataProvider fileFormatsProvider
+     */
+    public function testWritesSchemaToFileForAllFormats(
+        string $format,
+        bool $expectAnsi,
+        bool $expectMermaid,
+        bool $expectPhp
+    ): void {
+        $out = \sys_get_temp_dir() . '/schema_' . \bin2hex(\random_bytes(4));
         @unlink($out);
 
         $this->assertConsoleCommandOutputContainsStrings(
             'cycle:render',
-            ['format' => 'php', '--output' => $out, '--overwrite' => true],
+            ['--format' => $format, '--output' => $out],
             ['Schema written to']
         );
 
         $this->assertFileExists($out);
-        $schema = require $out;
-        $this->assertIsArray($schema);
+        $content = \file_get_contents($out);
+        $this->assertIsString($content);
+        $this->assertGreaterThan(0, \strlen($content));
 
-        @unlink($out);
+        // ANSI detection (color)
+        $hasAnsi = (bool)\preg_match('/\x1B\[[0-9;]*m/', $content);
+        $this->assertSame($expectAnsi, $hasAnsi, "ANSI expectation failed for format={$format}");
+
+        // Mermaid detection (line starts with known diagram markers)
+        $hasMermaid = (bool)\preg_match('/^(graph|classDiagram|erDiagram)\b/m', $content);
+        $this->assertSame($expectMermaid, $hasMermaid, "Mermaid expectation failed for format={$format}");
+
+        // PHP detection (file starts with `<?php`)
+        $hasPhp = (bool)\preg_match('/^\s*<\?php\b/m', $content);
+        $this->assertSame($expectPhp, $hasPhp, "PHP expectation failed for format={$format}");
+
+        if ($expectPhp) {
+            $schema = require $out;
+            $this->assertIsArray($schema);
+            $this->assertNotEmpty($schema);
+        } else {
+            $this->assertDoesNotMatchRegularExpression('/^\s*<\?php\b/m', $content);
+        }
+
+        @\unlink($out);
     }
 
-    public function testPreventOverwriteWithoutFlag(): void
+    public function testOverwriteOldFile(): void
     {
         $out = \sys_get_temp_dir() . '/schema_' . \bin2hex(\random_bytes(4)) . '.php';
         \file_put_contents($out, "<?php return ['_touched' => true];");
 
         $this->assertConsoleCommandOutputContainsStrings(
             'cycle:render',
-            ['format' => 'php', '--output' => $out],
-            ['File already exists:', 'use --overwrite to replace']
-        );
-
-        // файл остался прежним
-        $schema = require $out;
-        $this->assertArrayHasKey('_touched', $schema);
-
-        @unlink($out);
-    }
-
-    public function testOverwriteWithFlag(): void
-    {
-        $out = \sys_get_temp_dir() . '/schema_' . \bin2hex(\random_bytes(4)) . '.php';
-        \file_put_contents($out, "<?php return ['_touched' => true];");
-
-        $this->assertConsoleCommandOutputContainsStrings(
-            'cycle:render',
-            ['format' => 'php', '--output' => $out, '--overwrite' => true],
+            ['--format' => 'php', '--output' => $out],
             ['Schema written to']
         );
 
@@ -154,20 +163,18 @@ final class RenderCommandTest extends ConsoleTest
         $out = \sys_get_temp_dir() . '/schema_' . \bin2hex(\random_bytes(4)) . '.php';
         @unlink($out);
 
-        // В фикстурах Spiral обычно есть роли 'user','role','token' (смотри существующий тест mermaid)
         $requested = ['user', 'role'];
 
         $this->assertConsoleCommandOutputContainsStrings(
             'cycle:render',
-            ['format' => 'php', '--output' => $out, '--overwrite' => true, '--role' => [implode(',', $requested)]],
+            ['roles' => [implode(',', $requested)], '--format' => 'php', '--output' => $out],
             ['Schema written to']
         );
 
         $schema = require $out;
         $this->assertIsArray($schema);
 
-        // Все ключи схемы должны быть из запрошенного набора
-        foreach (array_keys($schema) as $key) {
+        foreach (\array_keys($schema) as $key) {
             $this->assertContains($key, $requested);
         }
 
@@ -183,10 +190,9 @@ final class RenderCommandTest extends ConsoleTest
         $this->assertConsoleCommandOutputContainsStrings(
             'cycle:render',
             [
-                'format'    => 'php',
+                'roles'      => ['user,does_not_exist'],
+                '--format'    => 'php',
                 '--output'    => $out,
-                '--overwrite' => true,
-                '--role'      => ['user,does_not_exist'],
             ],
             [
                 'Warning: unknown role(s) ignored: does_not_exist.',
@@ -199,53 +205,31 @@ final class RenderCommandTest extends ConsoleTest
         $this->assertArrayHasKey('user', $schema);
         $this->assertArrayNotHasKey('does_not_exist', $schema);
 
-        @unlink($out);
+        @\unlink($out);
     }
 
-    public function testAllUnknownRolesLeadsToNothingToWrite(): void
+    public function testAllUnknownRolesBehavior(): void
     {
         $out = \sys_get_temp_dir() . '/schema_' . \bin2hex(\random_bytes(4)) . '.php';
-        @unlink($out);
+        @\unlink($out);
 
         $this->assertConsoleCommandOutputContainsStrings(
             'cycle:render',
-            ['format' => 'php', '--output' => $out, '--role' => ['foo,bar']],
+            ['roles' => ['foo,bar'], '--format' => 'php', '--output' => $out],
             [
-                'Nothing to write.',
+                'Nothing to write',
             ]
         );
 
         $this->assertFileDoesNotExist($out);
-    }
 
-    public function testRolesCsvAndRepeatOptionsAreMerged(): void
-    {
-        $out = sys_get_temp_dir() . '/schema_' . bin2hex(random_bytes(4)) . '.php';
-        @unlink($out);
-
-        // проверяем смешанный ввод: повторяемая опция + CSV + разный регистр
         $this->assertConsoleCommandOutputContainsStrings(
             'cycle:render',
+            ['roles' => ['foo,bar'], '--format' => 'plain'],
             [
-                'format'    => 'php',
-                '--output'    => $out,
-                '--overwrite' => true,
-                '--role'      => ['User', 'role,address'],
-            ],
-            ['Schema written to']
+                'No roles matched the provided filter',
+            ]
         );
-
-        $schema = require $out;
-        $this->assertIsArray($schema);
-
-        // ожидаем хотя бы user/role/token (если они есть в фикстуре)
-        $keys = array_keys($schema);
-        $this->assertNotEmpty($keys);
-        foreach ($keys as $k) {
-            $this->assertContains($k, ['user', 'role', 'address']);
-        }
-
-        @unlink($out);
     }
 
     public function testRolesFilterWorksForPlainStdout(): void
@@ -255,7 +239,7 @@ final class RenderCommandTest extends ConsoleTest
 
         $out = new BufferedOutput();
 
-        $code = $console->run('cycle:render', ['format' => 'mermaid', '--role' => ['role']], $out);
+        $code = $console->run('cycle:render', ['roles' => ['role'], '--format' => 'mermaid'], $out);
 
         $display = $out->fetch();
 

--- a/tests/src/Console/Command/CycleOrm/RenderCommandTest.php
+++ b/tests/src/Console/Command/CycleOrm/RenderCommandTest.php
@@ -12,6 +12,20 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 final class RenderCommandTest extends ConsoleTest
 {
+    /**
+     * @return array<string, array{0:string,1:bool,2:bool,3:bool}>
+     *              [format, expectAnsi, expectMermaidKeyword, expectPhp]
+     */
+    public static function fileFormatsProvider(): array
+    {
+        return [
+            'plain'   => ['plain',   false, false, false],
+            'color'   => ['color',   true,  false, false],
+            'mermaid' => ['mermaid', false, true,  false],
+            'php'     => ['php',     false, false, true],
+        ];
+    }
+
     public function testRenderInMermaidFormat(): void
     {
         $this->assertConsoleCommandOutputContainsStrings('cycle:render', ['--format' => 'mermaid'], [
@@ -81,35 +95,21 @@ final class RenderCommandTest extends ConsoleTest
     }
 
     /**
-     * @return array<string, array{0:string,1:bool,2:bool,3:bool}>
-     *              [format, expectAnsi, expectMermaidKeyword, expectPhp]
-     */
-    public static function fileFormatsProvider(): array
-    {
-        return [
-            'plain'   => ['plain',   false, false, false],
-            'color'   => ['color',   true,  false, false],
-            'mermaid' => ['mermaid', false, true,  false],
-            'php'     => ['php',     false, false, true],
-        ];
-    }
-
-    /**
      * @dataProvider fileFormatsProvider
      */
     public function testWritesSchemaToFileForAllFormats(
         string $format,
         bool $expectAnsi,
         bool $expectMermaid,
-        bool $expectPhp
+        bool $expectPhp,
     ): void {
         $out = \sys_get_temp_dir() . '/schema_' . \bin2hex(\random_bytes(4));
-        @unlink($out);
+        @\unlink($out);
 
         $this->assertConsoleCommandOutputContainsStrings(
             'cycle:render',
             ['--format' => $format, '--output' => $out],
-            ['Schema written to']
+            ['Schema successfully written to'],
         );
 
         $this->assertFileExists($out);
@@ -118,15 +118,15 @@ final class RenderCommandTest extends ConsoleTest
         $this->assertGreaterThan(0, \strlen($content));
 
         // ANSI detection (color)
-        $hasAnsi = (bool)\preg_match('/\x1B\[[0-9;]*m/', $content);
+        $hasAnsi = (bool) \preg_match('/\x1B\[[0-9;]*m/', $content);
         $this->assertSame($expectAnsi, $hasAnsi, "ANSI expectation failed for format={$format}");
 
         // Mermaid detection (line starts with known diagram markers)
-        $hasMermaid = (bool)\preg_match('/^(graph|classDiagram|erDiagram)\b/m', $content);
+        $hasMermaid = (bool) \preg_match('/^(graph|classDiagram|erDiagram)\b/m', $content);
         $this->assertSame($expectMermaid, $hasMermaid, "Mermaid expectation failed for format={$format}");
 
         // PHP detection (file starts with `<?php`)
-        $hasPhp = (bool)\preg_match('/^\s*<\?php\b/m', $content);
+        $hasPhp = (bool) \preg_match('/^\s*<\?php\b/m', $content);
         $this->assertSame($expectPhp, $hasPhp, "PHP expectation failed for format={$format}");
 
         if ($expectPhp) {
@@ -148,27 +148,27 @@ final class RenderCommandTest extends ConsoleTest
         $this->assertConsoleCommandOutputContainsStrings(
             'cycle:render',
             ['--format' => 'php', '--output' => $out],
-            ['Schema written to']
+            ['Schema successfully written'],
         );
 
         $schema = require $out;
         $this->assertIsArray($schema);
         $this->assertArrayNotHasKey('_touched', $schema);
 
-        @unlink($out);
+        @\unlink($out);
     }
 
     public function testRolesFilterSubset(): void
     {
         $out = \sys_get_temp_dir() . '/schema_' . \bin2hex(\random_bytes(4)) . '.php';
-        @unlink($out);
+        @\unlink($out);
 
         $requested = ['user', 'role'];
 
         $this->assertConsoleCommandOutputContainsStrings(
             'cycle:render',
-            ['roles' => [implode(',', $requested)], '--format' => 'php', '--output' => $out],
-            ['Schema written to']
+            ['roles' => [\implode(',', $requested)], '--format' => 'php', '--output' => $out],
+            ['Schema successfully written'],
         );
 
         $schema = require $out;
@@ -178,13 +178,13 @@ final class RenderCommandTest extends ConsoleTest
             $this->assertContains($key, $requested);
         }
 
-        @unlink($out);
+        @\unlink($out);
     }
 
     public function testWarnOnUnknownRolesButProceed(): void
     {
         $out = \sys_get_temp_dir() . '/schema_' . \bin2hex(\random_bytes(4)) . '.php';
-        @unlink($out);
+        @\unlink($out);
 
         // 'user' существует, 'does_not_exist' — нет
         $this->assertConsoleCommandOutputContainsStrings(
@@ -195,9 +195,9 @@ final class RenderCommandTest extends ConsoleTest
                 '--output'    => $out,
             ],
             [
-                'Warning: unknown role(s) ignored: does_not_exist.',
-                'Schema written to',
-            ]
+                'No roles were found for `does_not_exist`.',
+                'Schema successfully written',
+            ],
         );
 
         $schema = require $out;
@@ -217,8 +217,8 @@ final class RenderCommandTest extends ConsoleTest
             'cycle:render',
             ['roles' => ['foo,bar'], '--format' => 'php', '--output' => $out],
             [
-                'Nothing to write',
-            ]
+                'No roles were found for `foo`, `bar`.',
+            ],
         );
 
         $this->assertFileDoesNotExist($out);
@@ -227,8 +227,8 @@ final class RenderCommandTest extends ConsoleTest
             'cycle:render',
             ['roles' => ['foo,bar'], '--format' => 'plain'],
             [
-                'No roles matched the provided filter',
-            ]
+                'No roles were found for `foo`, `bar`.',
+            ],
         );
     }
 


### PR DESCRIPTION
- New option to write Cycle ORM schema to a PHP file for `cycle:render`
- Filter by roles to limit the exported subset
- Overwrite flag to safely replace existing file

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

- Extended the existing `cycle:render` console command:
  - `-o, --output=/path/to/schema.php` — writes rendered schema to a file (supported **only for** `format=php`).
  - `--overwrite` — allows replacing an existing output file.
  - `-r, --role=<role> [--role=<role> ...]` — filters the rendered schema by roles; accepts multiple flags and comma-separated values (e.g. `--role=auth,rbac --role=default`).
- STDOUT behavior for all formats is preserved. If `--output` is not provided, output goes to STDOUT as before.
- For non-`php` formats with `--output`, the command fails with an explicit error.
- Safe write: content is written to a temporary file in the target directory and then atomically moved to the destination; parent directories are created as needed.

**Examples**
```bash
# to stdout (unchanged)
php app.php cycle:render php

# to file
php app.php cycle:render php --output=var/schema.php

# filter by roles (comma-separated, or multiple --role flags)
php app.php cycle:render php --output=var/schema.auth.php --role=auth,rbac
php app.php cycle:render php --output=var/schema.default.php --role=default --overwrite
```
### Edge cases & messages
- Unknown roles are reported as a warning and ignored.
- If the role filter yields no entries:
    - with `--output` → prints “Nothing to write.” and exits successfully;
    - without `--output` → prints an empty line to STDOUT.
- If the destination file already exists without `--overwrite`, the command fails with an explicit message.
- Directory creation and file write failures are reported with descriptive errors.

## Why?
- A deterministic PHP artifact of the schema is useful for audits, code reviews, caching in CI and reproducible builds.
- Role-based filtering keeps artifacts minimal and context-specific (e.g., exporting only auth-related roles).
- Preserving STDOUT behavior keeps the command backward compatible, while `--output` enables file-based workflows.

## Checklist

- Closes #29
- Tested
    - [x] Tested manually
    - [x] Unit tests added

## Documentation <!--- Remove if not needed -->
**New options:**
- `-o, --output=PATH` — write rendered schema to a PHP file (supported **only** when `format=php`).
- `--overwrite` — allow replacing an existing output file.
- `-r, --role=ROLE` — filter exported schema by roles (for any format).  
  Accepts multiple flags and comma-separated values inside a flag (e.g. `--role=auth,rbac --role=default`).  
  Role matching is case-insensitive; unknown roles are ignored with a warning.

**Behavior & edge cases:**
- Without `--output` the command writes to **STDOUT** (unchanged behavior).
- If `--output` is used with a non-`php` format → the command fails with an explicit error.
- If filtering results in an empty schema:
  - with `--output` → prints “Nothing to write.” and exits successfully;
  - without `--output` → prints an empty line to STDOUT.
- Safe write: schema is written to a temp file in the target dir and then atomically moved; parent dirs are created if missing.

**Examples**
```bash
# stdout (unchanged)
php app.php cycle:render php

# write to file
php app.php cycle:render php --output=var/schema.php

# filter by roles (comma-separated or multiple flags)
php app.php cycle:render php --output=var/schema.auth.php --role=auth,rbac
php app.php cycle:render php --output=var/schema.default.php --role=default --overwrite
```